### PR TITLE
Fix Overlapping [Issue #3]

### DIFF
--- a/styles/classicpress-editor.css
+++ b/styles/classicpress-editor.css
@@ -1,4 +1,13 @@
 /* Hide core CP word count at lower-left of editor; preserve the space. */
 #wp-word-count {
 	visibility:hidden;
-	}
+}
+
+
+/* Fix issues with z-index and the admin menu and bar 
+ {This CSS changes should better be applied to core once the editor is backed into it}
+*/
+#wpadminbar,
+#adminmenuwrap {
+	z-index: 1199;
+}


### PR DESCRIPTION
GH Issue: https://github.com/ClassicPress-research/ClassicPress-Editor/issues/3

Applied the new z-index value for `#wpadminbar` and `#adminmenuwrap`. It seems to work fine:

**Fullscreen screenshot**:

![image](https://user-images.githubusercontent.com/83215112/131867225-5f7682c8-859c-453b-933f-d504f89ee894.png)

**Insert/edit code screenshot**:

![image](https://user-images.githubusercontent.com/83215112/131867294-fe9763db-8f98-45c1-9345-baaaa418cca7.png)

**View source code screenshot**:

![image](https://user-images.githubusercontent.com/83215112/131867402-a2cebad2-03a4-4a17-a253-55374d316cd6.png)

If the editor gets backed into core, the CSS rules should actually be replaced in core admin css files, instead of having a z-index mess floating around.


