### PR TITLE
Add missing fullscreen style for z-index

### DIFF
--- a/js/tinymce/plugins/compat4x/plugin.js
+++ b/js/tinymce/plugins/compat4x/plugin.js
@@ -149,7 +149,8 @@
 .post-php.tox-fullscreen #wpadminbar,\
 .tox-fullscreen #wp-content-wrap .mce-wp-dfw {\
 	display: none;\
-}';
+}\
+.tox-fullscreen {z-index: 100010 !important;}';
 			hStyle.innerHTML = css;
 
 			//This moves the textarea to the bottom, like it is on 4.x

--- a/js/tinymce/plugins/compat4x/plugin.min.js
+++ b/js/tinymce/plugins/compat4x/plugin.min.js
@@ -149,7 +149,8 @@
 .post-php.tox-fullscreen #wpadminbar,\
 .tox-fullscreen #wp-content-wrap .mce-wp-dfw {\
 	display: none;\
-}';
+}\
+.tox-fullscreen {z-index: 100010 !important;}';
 			hStyle.innerHTML = css;
 
 			//This moves the textarea to the bottom, like it is on 4.x


### PR DESCRIPTION
The class name for fullscreen mode is added dynamically to the page, so the patched CSS for the new class name was added, but it was missing the rule for the large z-index.
Eventually, this CSS will replace the rules in editor.css.

To test, put your cursor in the iframe and use the fullscreen shortcut: Ctrl-Shift-F