### PR TITLE
For removed functions: allow simple calls to work, fallback to 5.x error for others

### DIFF
--- a/classicpress-editor.php
+++ b/classicpress-editor.php
@@ -4,7 +4,7 @@
  * -----------------------------------------------------------------------------
  * Plugin Name: ClassicPress Editor - Experimental
  * Description: An integration of TinyMCE version 5.9.  This plugin is not yet intended for production use.
- * Version: 1.0.2-alpha
+ * Version: 1.0.3-alpha
  * Author: John Alarcon, Joy Reynolds, and ClassicPress Contributors
  * Author URI: https://www.classicpress.net
  * Text Domain: classicpress-editor

--- a/js/tinymce/wp-tinymce.php
+++ b/js/tinymce/wp-tinymce.php
@@ -65,7 +65,7 @@ if ( isset($_GET['c']) && 1 == $_GET['c'] && isset($_SERVER['HTTP_ACCEPT_ENCODIN
 	} );
 <?php
 	echo get_file( $basepath . '/tinymce.min.js' );
-	echo get_file( $basepath . '/plugins/compat3x/plugin.min.js' );
+//	echo get_file( $basepath . '/plugins/compat3x/plugin.min.js' );
 	echo get_file( $basepath . '/plugins/compat4x/plugin.min.js' );
 }
 exit;


### PR DESCRIPTION
The `addButton`, `addMenuItem`, `addContextToolbar`, and `addSidebar` functions were moved in 5.x and the API is different.
The `compat4x` plugin was originally a passthrough, so those functions would not fail, but they failed anyway since the API changed.
These changes allow the basic `addButton` and `addMenuItem` calls to work, but the ones with complicated parameters need to change for the API so the 5.x error is thrown. The `addContextToolbar`, and `addSidebar` functions are less used and less obvious for how to patch, so they will get the 5.x error.
Addresses #20 